### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -767,6 +767,101 @@
                 line-height: 5rem;
             }
         }
+
+        /* =================================
+           MOBILE LANDSCAPE
+        ================================= */
+
+        @media (orientation: landscape) and (max-width: 1024px) {
+            .touch-controls {
+                height: 80px;
+            }
+
+            .touch-btn-left {
+                bottom: 10px;
+                left: 10px;
+                width: 50px;
+                height: 50px;
+            }
+
+            .touch-btn-right {
+                bottom: 10px;
+                left: 70px;
+                width: 50px;
+                height: 50px;
+            }
+
+            .touch-btn-duck {
+                bottom: 10px;
+                right: 80px;
+                width: 40px;
+                height: 40px;
+            }
+
+            .touch-btn-jump {
+                bottom: 10px;
+                right: 20px;
+                width: 60px;
+                height: 60px;
+            }
+
+            .question-display {
+                bottom: 90px;
+                font-size: 0.9rem;
+            }
+
+            .game-info {
+                top: 5px;
+                font-size: 0.7rem;
+            }
+        }
+
+        /* =================================
+           MOBILE PORTRAIT
+        ================================= */
+
+        @media (orientation: portrait) and (max-width: 768px) {
+            .touch-controls {
+                height: 120px;
+            }
+
+            .touch-btn-left {
+                bottom: 20px;
+                left: 20px;
+                width: 60px;
+                height: 60px;
+            }
+
+            .touch-btn-right {
+                bottom: 20px;
+                left: 110px;
+                width: 60px;
+                height: 60px;
+            }
+
+            .touch-btn-duck {
+                bottom: 20px;
+                right: 110px;
+                width: 50px;
+                height: 50px;
+            }
+
+            .touch-btn-jump {
+                bottom: 20px;
+                right: 20px;
+                width: 70px;
+                height: 70px;
+            }
+
+            .question-display {
+                bottom: 110px;
+                font-size: 1.1rem;
+            }
+
+            .game-info {
+                font-size: 0.8rem;
+            }
+        }
     </style>
 </head>
 <body>
@@ -961,8 +1056,9 @@
 
             console.log("DEBUG: Creating camera...");
             camera = new THREE.PerspectiveCamera(75, (canvas.clientWidth || 1) / (canvas.clientHeight || 1), 0.1, 2000); 
-            camera.position.set(0, 2.5, 5); 
-            camera.lookAt(0, 1.0, 0); 
+            camera.position.set(0, 2.5, 5);
+            camera.lookAt(0, 1.0, 0);
+            adjustCameraForAspect();
             console.log("DEBUG: Camera created successfully");
 
             console.log("DEBUG: Creating renderer...");
@@ -1609,6 +1705,15 @@
             }
         }
 
+        function adjustCameraForAspect() {
+            if (!camera) return;
+            if (camera.aspect < 1) {
+                camera.position.z = 7;
+            } else {
+                camera.position.z = 5;
+            }
+        }
+
         function resizeGame() { 
             const container = document.querySelector('.game-container');
             if (!container) {
@@ -1623,8 +1728,9 @@
             }
 
             if (renderer && camera) {
-                renderer.setSize(newWidth || 300, newHeight || 150); 
-                camera.aspect = (newWidth || 1) / (newHeight || 1); 
+                renderer.setSize(newWidth || 300, newHeight || 150);
+                camera.aspect = (newWidth || 1) / (newHeight || 1);
+                adjustCameraForAspect();
                 camera.updateProjectionMatrix();
             }
          }
@@ -2426,6 +2532,7 @@
                         const container = canvas.parentElement;
                         renderer.setSize(container.clientWidth, container.clientHeight);
                         camera.aspect = container.clientWidth / container.clientHeight;
+                        adjustCameraForAspect();
                         camera.updateProjectionMatrix();
                     }
                 }, 100);


### PR DESCRIPTION
## Summary
- add CSS rules for portrait orientation
- tweak camera distance on portrait screens so the whole lane stays visible

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684c48365b108323aec0def8660b86c7