### PR TITLE
Fix mobile jump button event

### DIFF
--- a/index.html
+++ b/index.html
@@ -2387,7 +2387,7 @@
             } else if (e.key === 'ArrowRight') {
                 characterLane = Math.min(LANE_COUNT - 1, characterLane + 1);
             } else if ((e.key === ' ' || e.key === 'ArrowUp') && !isJumping) {
-                e.preventDefault(); // Previne que o espaço ative botões
+                if (e.preventDefault) e.preventDefault(); // Previne que o espaço ative botões
                 isJumping = true;
                 jumpVelocityY = JUMP_VELOCITY_INITIAL;
             }


### PR DESCRIPTION
## Summary
- handleKeyPress now checks if `preventDefault` exists before calling it for jump events

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c4d6956e88323b60b3d7cb07478fe