### PR TITLE
Fix viewport height on mobile using visualViewport

### DIFF
--- a/index.html
+++ b/index.html
@@ -956,13 +956,20 @@
     document.addEventListener('DOMContentLoaded', function() {
         // CÓDIGO CORRIGIDO ABAIXO
         function updateViewportHeight() {
-            // Calcula 1% da altura da janela interna (viewport)
-            let vh = window.innerHeight * 0.01;
+            // Prefere o visualViewport se estiver disponível para obter a altura real
+            const viewportHeight =
+                (window.visualViewport && window.visualViewport.height) ||
+                window.innerHeight;
+            // Calcula 1% da altura da área visível
+            const vh = viewportHeight * 0.01;
             // Define o valor da variável '--vh' no elemento raiz (<html>)
             document.documentElement.style.setProperty('--vh', `${vh}px`);
         }
         window.addEventListener('resize', updateViewportHeight);
         window.addEventListener('orientationchange', updateViewportHeight);
+        if (window.visualViewport) {
+            window.visualViewport.addEventListener('resize', updateViewportHeight);
+        }
         updateViewportHeight();
 
         // Elementos da UI


### PR DESCRIPTION
## Summary
- keep the start screen sized correctly by using `visualViewport.height` when available
- listen for `visualViewport` resize events so `--vh` updates on mobile

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684c5b968bdc8323bc3cace4254d5ae3