### PR TITLE
Fix: Ensure next question loads after using tip during transition

### DIFF
--- a/index.html
+++ b/index.html
@@ -1337,7 +1337,11 @@
             answersVisible = false;
             answerBoxes.forEach(box => { box.visible = false; });
             setTimeout(() => {
-                if(gameState === 'playing') { updateAnswerBoxesVisibilityAndText(); answersVisible = true; questionTimer = 0; }
+                // This logic should run regardless of whether the game is paused when the timeout fires.
+                // The game loop (animate/updateGameLogic) will handle the state correctly when 'playing'.
+                updateAnswerBoxesVisibilityAndText();
+                answersVisible = true;
+                questionTimer = 0;
             }, QUESTION_TO_ANSWERS_DELAY);
         }
         function handleAnswerSelection(collidedBoxIndex, collidedBoxMesh) {


### PR DESCRIPTION
Previously, if the AI tip button was used (which pauses the game) during the brief period when a new question was being generated (after the old one was cleared but before new answers were made visible), the game could get stuck. The new question's answers would not appear after resuming the game.

This was because the `setTimeout` callback in `generateQuestion` responsible for making answers visible and resetting the question timer was guarded by an `if(gameState === 'playing')` condition. If this timeout fired while the game was paused, this setup logic was skipped.

The fix removes this condition from the core setup logic within the `setTimeout` callback. Now, `answersVisible` is set to `true` and `questionTimer` is reset for the new question regardless of the game state when the timeout fires. The main game loop correctly handles this state upon resuming, ensuring the new question is displayed and interactive.